### PR TITLE
Safe packages upgrade + Added Eslint linter

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": [
+    "next/core-web-vitals",
+    "next/typescript"
+  ]
+}

--- a/components/Favicon.tsx
+++ b/components/Favicon.tsx
@@ -1,3 +1,5 @@
+import Image from "next/image";
+
 type FaviconProps = {
   url: string | null;
 };
@@ -5,13 +7,12 @@ type FaviconProps = {
 const Favicon = ({ url }: FaviconProps) => {
   return (
     <div className="inline-flex size-6 items-center justify-center shrink-0 rounded-md border bg-background p-1 favicon-custom-css">
-      <img
+      <Image
         loading="lazy"
         width="64"
         height="64"
         className="aspect-square size-6 rounded"
-        src={`https://www.google.com/s2/favicons?sz=128&domain_url=${url}`}
-      />
+        src={`https://www.google.com/s2/favicons?sz=128&domain_url=${url}`} alt={""}      />
     </div>
   );
 };

--- a/components/StarBadge.tsx
+++ b/components/StarBadge.tsx
@@ -33,6 +33,8 @@ const StarIcon = React.memo(() => (
   </svg>
 ));
 
+StarIcon.displayName = "StarIcon";
+
 const StarBadge = ({ repoURL }) => {
   const [stars, setStars] = useState(null);
   const [loading, setLoading] = useState(true);

--- a/components/TableRow.tsx
+++ b/components/TableRow.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-// Memoized StarIcon component
+// Memoized StarIcon component with display name
 const StarIcon = React.memo(() => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
@@ -19,6 +19,7 @@ const StarIcon = React.memo(() => (
     />
   </svg>
 ));
+StarIcon.displayName = "StarIcon"; // Assign display name
 
 interface TableRowProps {
   repoURL: string;
@@ -26,6 +27,7 @@ interface TableRowProps {
   error: string | null;
 }
 
+// Memoized TableRow component with display name
 const TableRow: React.FC<TableRowProps> = React.memo(
   ({ repoURL, stars, error }) => {
     if (!repoURL) {
@@ -54,5 +56,6 @@ const TableRow: React.FC<TableRowProps> = React.memo(
     );
   }
 );
+TableRow.displayName = "TableRow"; // Assign display name
 
 export default TableRow;

--- a/components/badges/Favicon.tsx
+++ b/components/badges/Favicon.tsx
@@ -1,3 +1,5 @@
+import Image from "next/image";
+
 type FaviconProps = {
   url: string | null;
 };
@@ -5,11 +7,10 @@ type FaviconProps = {
 const Favicon = ({ url }: FaviconProps) => {
   return (
     <span className="inline-flex size-6 items-center justify-center shrink-0 rounded-md bg-background p-1 favicon-custom-css">
-      <img
+      <Image
         loading="lazy"
         className="aspect-square h-3"
-        src={`https://www.google.com/s2/favicons?sz=128&domain_url=${url}`}
-      />
+        src={`https://www.google.com/s2/favicons?sz=128&domain_url=${url}`} alt={""}      />
     </span>
   );
 };

--- a/components/badges/MostStarredRepoBadge.tsx
+++ b/components/badges/MostStarredRepoBadge.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Button, Typography, Tooltip } from "antd";
+import { Button, Typography } from "antd";
 
 const { Text } = Typography;
 

--- a/components/badges/TeamGithubBadge.tsx
+++ b/components/badges/TeamGithubBadge.tsx
@@ -29,4 +29,7 @@ const TeamGithubBadge: React.FC<TeamGithubBadgeProps> = React.memo(
   }
 );
 
+// Assign display name to the memoized component
+TeamGithubBadge.displayName = "TeamGithubBadge";
+
 export default TeamGithubBadge;

--- a/components/badges/shield_io_badges/CodeLanguageShieldIoBadge.tsx
+++ b/components/badges/shield_io_badges/CodeLanguageShieldIoBadge.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import Image from "next/image";
 
 const CodeLanguageShieldIoBadge = ({ language }) => {
   if (!language) return null;
@@ -90,12 +91,12 @@ const CodeLanguageShieldIoBadge = ({ language }) => {
           }
         `}
       </style>
-      <img
+      <Image
         src={`https://img.shields.io/badge/${language}-ffffff?style=flat&logo=${languageLower}&logoColor=${logoColor}`}
         className="shields_io_language_badge light"
         alt={`${language} badge`}
       />
-      <img
+      <Image
         src={`https://img.shields.io/badge/${language}-1a1a1a?style=flat&logo=${languageLower}&logoColor=${logoColor}`}
         className="shields_io_language_badge dark"
         alt={`${language} badge`}

--- a/components/badges/shield_io_badges/RepoShieldIoBadge.tsx
+++ b/components/badges/shield_io_badges/RepoShieldIoBadge.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import Image from "next/image";
 
 interface RepoShieldIoBadgeProps {
   githubUrl: string;
@@ -23,7 +24,7 @@ const RepoShieldIoBadge: React.FC<RepoShieldIoBadgeProps> = React.memo(
 
     return (
       <a href={githubUrl} target="_blank" rel="noopener noreferrer">
-        <img
+        <Image
           src={shieldsIoUrl}
           className="shields_io_repo_badge"
           alt={`${text} repo link`}
@@ -32,5 +33,8 @@ const RepoShieldIoBadge: React.FC<RepoShieldIoBadgeProps> = React.memo(
     );
   }
 );
+
+// Assign display name to the memoized component
+RepoShieldIoBadge.displayName = "RepoShieldIoBadge";
 
 export default RepoShieldIoBadge;

--- a/components/hero.js
+++ b/components/hero.js
@@ -1,8 +1,6 @@
 import React from "react";
 import Image from "next/image";
 import BGImg from "./../assets/dark/1.jpg";
-import { handleHeroButtonClick } from "../scripts/handleHeroButtonClick";
-import { handleHeroButtonClickMobile } from "../scripts/handleHeroButtonClickMobile";
 
 function Hero() {
   return (

--- a/components/tables/OpenSourceBuildersTable.jsx
+++ b/components/tables/OpenSourceBuildersTable.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Table, Tag, Typography, Tooltip, Button, Card, Space } from "antd";
+import { Table, Typography, Tooltip, Button, Card } from "antd";
 import { StarIcon } from "../../assets/icons";
 import TeamGithubBadge from "@components/badges/TeamGithubBadge";
 import CodeLanguageShieldIoBadge from "@components/badges/shield_io_badges/CodeLanguageShieldIoBadge";

--- a/next.config.js
+++ b/next.config.js
@@ -7,7 +7,11 @@ module.exports = withNextra({
   env: {
     GITHUB_ACCESS_TOKEN: process.env.GITHUB_ACCESS_TOKEN,
   },
-
+  eslint: {
+    // Warning: This allows production builds to successfully complete even if
+    // your project has ESLint errors.
+    ignoreDuringBuilds: true,
+  },
   async redirects() {
     return [
       {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "lint": "next lint"
   },
   "repository": {
     "type": "git",
@@ -35,9 +36,6 @@
     "@types/node": "22.10.1",
     "@types/react": "18.3.12",
     "autoprefixer": "^10.4.20",
-    "eslint": "^9.16.0",
-    "eslint-config-next": "^15.0.4",
-    "eslint-define-config": "^2.1.0",
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.16",
     "typescript": "^5.7.2"

--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
     "@octokit/plugin-retry": "^7.1.2",
     "@octokit/plugin-throttling": "^9.3.2",
     "@octokit/rest": "^21.0.2",
-    "antd": "^5.22.1",
+    "antd": "^5.22.3",
     "antd-style": "^3.7.1",
     "javascript-time-ago": "^2.5.11",
-    "next": "15.0.3",
+    "next": "15.0.4",
     "nextra": "^2.13.4",
     "nextra-theme-docs": "^2.13.4",
     "react": "18.3.1",
@@ -34,10 +34,13 @@
     "@svgr/webpack": "^8.1.0",
     "@types/node": "22.10.1",
     "@types/react": "18.3.12",
-    "autoprefixer": "^10.4.18",
-    "postcss": "^8.4.35",
-    "tailwindcss": "^3.4.1",
-    "typescript": "^5.4.5"
+    "autoprefixer": "^10.4.20",
+    "eslint": "^9.16.0",
+    "eslint-config-next": "^15.0.4",
+    "eslint-define-config": "^2.1.0",
+    "postcss": "^8.4.49",
+    "tailwindcss": "^3.4.16",
+    "typescript": "^5.7.2"
   },
   "pnpm": {
     "overrides": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
     "@types/node": "22.10.1",
     "@types/react": "18.3.12",
     "autoprefixer": "^10.4.20",
+    "eslint": "^9.16.0",
+    "eslint-config-next": "^15.0.4",
+    "eslint-define-config": "^2.1.0",
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.16",
     "typescript": "^5.7.2"

--- a/pages/api/open_source_builders.ts
+++ b/pages/api/open_source_builders.ts
@@ -1207,6 +1207,7 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
     res.status(200).json(openSourceBuildersData);
   } catch (err) {
+    console.error(err); // Use err for logging or debugging
     res.status(500).json({
       success: false,
       message: "Failed to fetch builders data",


### PR DESCRIPTION
Hello AdaStack.io team,

please find this simple first update:

1. Package upgrades

pnpm up && pnpm outdated

![image](https://github.com/user-attachments/assets/4a3f31b1-25d0-434c-8f83-89f848fbe315)


We upgraded "next" to 15.0.4 which is the only one in the list that can be safely upgraded.

Other packages:

@types/react (dev)
nextra
nextra-theme-docs
react
react-dom

Are marked in red, they have breaking changes. We previuosly tried to upgrade them all, but we got unmet peers deps warning for react packages, and compilation error on upgraded nextra and nextra-theme-docs.

pnpm up next@15.0.4

2. Linting

added "eslint" linter in devDependencies and "lint": "next lint" in package.json

pnpm add -D eslint eslint-config-next eslint-define-config

devDependencies:
+ eslint 9.16.0
+ eslint-config-next 15.0.4
+ eslint-define-config 2.1.0

Next PR will be about fixed linting errors.

Cheers,
Manuel 