### PR TITLE
Add jpg store nft marketplace

### DIFF
--- a/data/builders.json
+++ b/data/builders.json
@@ -5926,6 +5926,12 @@
     "teamGithubURL": "https://github.com/JamOnBread",
     "tags": ["info", "nft_guide"]
   },
+    {
+    "name": "jpg.store",
+    "website": "https://www.jpg.store/",
+    "teamGithubURL": "https://github.com/jpg-store",
+    "tags": ["dapp", "nft_marketplace"]
+  },
   {
     "name": "Kreate Art",
     "website": "https://kreate.community/",

--- a/data/builders.json
+++ b/data/builders.json
@@ -5927,7 +5927,7 @@
     "tags": ["info", "nft_guide"]
   },
     {
-    "name": "jpg.store",
+    "name": "JPG Store",
     "website": "https://www.jpg.store/",
     "teamGithubURL": "https://github.com/jpg-store",
     "tags": ["dapp", "nft_marketplace"]


### PR DESCRIPTION
This PR adds the jpg.store marketplace to the list of NFT marketplaces.